### PR TITLE
temp: partial fix for update 0.220.3

### DIFF
--- a/Guilds/API.Structures.cs
+++ b/Guilds/API.Structures.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -6,7 +6,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using BepInEx;
 using JetBrains.Annotations;
-#if ! API
+using Splatform;
+
 using YamlDotNet.Serialization;
 #endif
 
@@ -123,9 +124,9 @@ public class AchievementConfig
 [TypeConverter(typeof(PlayerReferenceTypeConverter))]
 public struct PlayerReference
 {
-	public static PlayerReference fromPlayerInfo(ZNet.PlayerInfo playerInfo) => new() { id = playerInfo.m_host.IsNullOrWhiteSpace() ? PrivilegeManager.GetNetworkUserId() : playerInfo.m_host.Contains("_") ? playerInfo.m_host : $"Steam_{playerInfo.m_host}", name = playerInfo.m_name ?? "" };
+	public static PlayerReference fromPlayerInfo(ZNet.PlayerInfo playerInfo) => new() { id = playerInfo.m_userInfo.m_id.ToString() };
 	public static PlayerReference fromPlayer(Player player) => player == Player.m_localPlayer ? forOwnPlayer() : fromPlayerInfo(ZNet.instance.m_players.FirstOrDefault(info => info.m_characterID == player.GetZDOID()));
-	public static PlayerReference forOwnPlayer() => new() { id = PrivilegeManager.GetNetworkUserId(), name = Game.instance.GetPlayerProfile().GetName() };
+	public static PlayerReference forOwnPlayer() => new() { id = PlatformManager.DistributionPlatform.LocalUser.PlatformUserID.ToString(), name = Game.instance.GetPlayerProfile().GetName() };
 #if !API
 	public static PlayerReference fromRPC(ZRpc? rpc) => rpc is null ? forOwnPlayer() : fromPlayerInfo(ZNet.instance.m_players.First(p => p.m_host == rpc.m_socket.GetHostName()));
 #endif

--- a/Guilds/Guilds.csproj
+++ b/Guilds/Guilds.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
     <PropertyGroup>
@@ -95,6 +95,10 @@
         </Reference>
         <Reference Include="ServerSync, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Condition=" '$(Configuration)|$(Platform)' != 'API|AnyCPU' ">
             <HintPath>Libs\ServerSync.dll</HintPath>
+        </Reference>
+        <Reference Include="Splatform">
+            <HintPath>$(GamePath)\valheim_Data\Managed\Splatform.dll</HintPath>
+            <Private>false</Private>
         </Reference>
         <Reference Include="StatManager">
             <HintPath>Libs\StatManager.dll</HintPath>

--- a/Guilds/Map.cs
+++ b/Guilds/Map.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -6,6 +6,7 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using HarmonyLib;
 using JetBrains.Annotations;
+using Splatform;
 using UnityEngine;
 
 namespace Guilds;
@@ -111,7 +112,7 @@ public static class Map
 
 		ColorUtility.TryParseHtmlString(guild.General.color, out Color color);
 
-		Chat.instance.RPC_ChatMessage(senderId, position, type, name, text, PrivilegeManager.GetNetworkUserId());
+		Chat.instance.RPC_ChatMessage(senderId, position, type, name, text, PlatformManager.DistributionPlatform.LocalUser.PlatformUserID.ToString());
 		Chat.WorldTextInstance worldText = Chat.instance.FindExistingWorldText(senderId);
 		worldText.m_textMeshField.color = color;
 		guildPingTexts.Add(worldText, Array.Empty<object>());


### PR DESCRIPTION
Following update 0.220.3, `PrivilegeManager` and associated code has been replaced by a new `PlatformManager` mechanism. Had a quick look to fix stuff on my end and I figured I could come up with something for `Guilds`, sending you the patch in case it may be useful.

Aside from that, `m_host` is not available anymore on `PlayerInfo`, but I couldn't quite find a suitable replacement to identify a player from a `ZRpc`, so this is not a complete fix... 😅